### PR TITLE
[eclipse/xtext#1508] Remove adding of upstream triggers

### DIFF
--- a/modify_files_for_release.groovy
+++ b/modify_files_for_release.groovy
@@ -18,24 +18,16 @@ switch (repoId) {
     gradle.gradleVersionUpdate(xtextVersion)
     pom.changePomDependencyVersion(xtextVersion,'releng/pom.xml', snapshotVersion)
     pom.setProperty('releng/pom.xml', 'upstreamBranch', branchName)
-    jenkinsfile.addDeclarativeUpstream('Jenkinsfile', 'xtext-lib', branchName)
-    jenkinsfile.addDeclarativeUpstream('CBI.Jenkinsfile', 'xtext-lib', branchName)
     break
   case 'xtext-extras' :
     gradle.gradleVersionUpdate(xtextVersion)
     pom.changePomDependencyVersion(xtextVersion, 'releng/pom.xml', snapshotVersion)
     pom.setProperty('releng/pom.xml', 'upstreamBranch', branchName)
-    jenkinsfile.addDeclarativeUpstream('Jenkinsfile', 'xtext-core', branchName)
-    jenkinsfile.addDeclarativeUpstream('CBI.Jenkinsfile', 'xtext-core', branchName)
     break
   case 'xtext-eclipse' :
-    jenkinsfile.addDeclarativeUpstream('Jenkinsfile', 'xtext-extras', branchName)
-    jenkinsfile.addDeclarativeUpstream('CBI.Jenkinsfile', 'xtext-extras', branchName)
     break
   case 'xtext-web' :
     gradle.gradleVersionUpdate(xtextVersion)
-    jenkinsfile.addDeclarativeUpstream('Jenkinsfile', 'xtext-extras', branchName)
-    jenkinsfile.addDeclarativeUpstream('CBI.Jenkinsfile', 'xtext-extras', branchName)
     break
   case 'xtext-maven' :
     pom.pomVersionUpdate('org.eclipse.xtext.maven.parent/pom.xml', xtextVersion)
@@ -43,9 +35,6 @@ switch (repoId) {
     pom.setProperty('org.eclipse.xtext.maven.parent/pom.xml', 'upstreamBranch', branchName)
     pom.setProperty('org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml', 'upstreamBranch', branchName)
     pom.setProperty('org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml', 'xtext-version', xtextVersion)
-    // TODO Change to declarative
-    jenkinsfile.addScriptedUpstream('Jenkinsfile', 'xtext-extras', branchName)
-    jenkinsfile.addDeclarativeUpstream('CBI.Jenkinsfile', 'xtext-extras', branchName)
     break
   case 'xtext-xtend' :
     gradle.gradleVersionUpdate(xtextVersion)
@@ -55,14 +44,8 @@ switch (repoId) {
     pom.pomVersionUpdate('releng/org.eclipse.xtend.maven.parent/pom.xml', xtextVersion)
     pom.setProperty('releng/org.eclipse.xtend.maven.parent/pom.xml', 'upstreamBranch', branchName)
     pom.setProperty('org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml', 'xtextVersion', xtextVersion)
-    // TODO Change to declarative
-    jenkinsfile.addScriptedUpstream('Jenkinsfile', 'xtext-eclipse', branchName)
-    jenkinsfile.addDeclarativeUpstream('CBI.Jenkinsfile', 'xtext-eclipse', branchName)
     break
   case 'xtext-umbrella' :
     pom.pomZipVersionUpdate(xtextVersion, 'releng/org.eclipse.xtext.sdk.p2-repository/pom.xml', snapshotVersion)
-    // TODO Change to declarative
-    jenkinsfile.addScriptedUpstream('Jenkinsfile', 'xtext-xtend', branchName)
-    jenkinsfile.addDeclarativeUpstream('CBI.Jenkinsfile', 'xtext-xtend', branchName)
     break
 }


### PR DESCRIPTION
The jobs now doing downstream triggering, so we do not need to add
upstream triggers anymore.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>